### PR TITLE
Add Bulk Signer documentation (English)

### DIFF
--- a/docs.en-us/articles/bulk-signer/configuration.md
+++ b/docs.en-us/articles/bulk-signer/configuration.md
@@ -1,0 +1,145 @@
+﻿# Bulk Signer - Configuration
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+All settings live in `appsettings.json` with environment overrides in `appsettings.{Development,Production,Docker}.json`. Any value can be overridden via environment variables using the standard `Section__Subsection__Key` pattern. Secrets are read **only** from environment variables (never logged).
+
+## Folders
+
+```json
+"Folders": {
+  "Input": "data/input",
+  "Processing": "data/processing",
+  "Output": "data/output",
+  "Error": "data/error",
+  "Logs": "data/logs"
+}
+```
+
+All five folders are created at startup and write-probed. Failure exits with code 4. In Docker the defaults are absolute paths under `/var/bulksigner/`.
+
+## Database
+
+```json
+"Database": { "Provider": "Sqlite", "ConnectionString": "Data Source=data/bulksigner.db" }
+```
+
+EF Core runs all pending migrations at startup. Failure exits with code 3.
+
+## Security
+
+```json
+"Security": {
+  "ApiKeyHeaderName": "X-API-Key",
+  "ApiKeyEnvironmentVariable": "BULKSIGNER_API_KEY",
+  "DashboardCookieExpirationHours": 8
+}
+```
+
+The API key is read from the env var. In Development, you may also set `Security:DevelopmentApiKey`. Production fails fast with code 2 if no key is present.
+
+## File validation
+
+```json
+"FileValidation": {
+  "AllowedExtensions": [".pdf", ".xml", ".txt", ".csv", ".zip"],
+  "MaxFileSizeMb": 100,
+  "ReadinessPollIntervalMilliseconds": 1000,
+  "ReadinessTimeoutSeconds": 300
+}
+```
+
+REST uploads exceeding `MaxFileSizeMb` return `413 Payload Too Large`. Watched-folder files exceeding the limit become `Rejected` jobs and move to Error.
+
+## Signing
+
+```json
+"Signing": {
+  "License": "<lacuna-license-string>",
+  "CertificateSource": "PfxFile|Pkcs11|WindowsStore",
+  "DefaultSignatureFormat": "Cades|Xades|Pades",
+  "Verification": { "Enabled": true, "FailJobOnVerificationError": true },
+  "PfxFile": {
+    "Path": "certificates/signer.pfx",
+    "PasswordEnvironmentVariable": "BULKSIGNER_PFX_PASSWORD"
+  },
+  "Pkcs11": {
+    "LibraryPath": "/usr/local/lib/libpkcs11.so",
+    "TokenLabel": "", "TokenSerialNumber": "", "SlotNumber": null,
+    "CertificateLabel": "", "CertificateId": "",
+    "PinEnvironmentVariable": "BULKSIGNER_HSM_PIN"
+  },
+  "WindowsStore": { "StoreName": "My", "StoreLocation": "CurrentUser", "Thumbprint": "" }
+}
+```
+
+* The Lacuna PKI SDK requires a valid license to load or sign anything. Set `Signing:License` (or the env var `Signing__License`). The provided dev license string MUST NOT be committed if it is licensed to a specific machine/customer.
+* `CertificateSource = WindowsStore` is rejected at startup on non-Windows hosts. Exit code 5.
+* For PKCS#11, the HSM PIN is read only from the env var. Integration depends on a vendor-provided `.so` / `.dll` PKCS#11 library — these are almost never built for musl, so the Docker image uses Debian-slim.
+
+## Timestamping (TSA)
+
+```json
+"Timestamping": {
+  "Enabled": false,
+  "TsaUrl": "",
+  "Username": "",
+  "PasswordEnvironmentVariable": "BULKSIGNER_TSA_PASSWORD",
+  "TimeoutSeconds": 30
+}
+```
+
+When enabled, signing jobs fail (rather than silently degrading) if the TSA request fails.
+
+## Encryption
+
+```json
+"Encryption": {
+  "Enabled": false,
+  "RecipientCertificatePath": "certificates/recipient.cer",
+  "ContentEncryptionAlgorithm": "AES-256-GCM",
+  "KeyProtectionFormat": "PKCS7-CMS-EnvelopedData"
+}
+```
+
+v1 implements AES-256-CBC inside PKCS#7 EnvelopedData (the spec mentions GCM; CBC is broadly portable across .NET on Windows and Linux and can be swapped without API changes). The recipient certificate must contain a usable RSA public key.
+
+## Retention
+
+```json
+"Retention": { "Enabled": true, "RetentionDays": 30, "CleanupIntervalHours": 24 }
+```
+
+Terminal jobs (Completed/Failed/Rejected/Canceled) older than `RetentionDays` are physically deleted, along with their `SigningJobEvent`s, output files, and error files. Manual trigger: `POST /api/cleanup/run` or the Dashboard.
+
+## Dashboard
+
+```json
+"Dashboard": { "HomeRefreshSeconds": 5, "JobsRefreshSeconds": 10, "JobDetailsRefreshSeconds": 5 }
+```
+
+Job-details auto-refresh stops once the job hits a terminal status.
+
+## Rate limiting and miscellany
+
+```json
+"RateLimiting": { "Enabled": true, "RequestsPerMinutePerIp": 60 },
+"Metrics": { "Enabled": true, "RequireApiKey": true },
+"Health": { "CacheSeconds": 5 },
+"Swagger": { "EnabledInProduction": false }
+```
+
+`Swagger:EnabledInProduction = true` enables the Scalar UI in Production (still gated by API key when relevant). In Development it's always on.
+
+## Secrets — env-var checklist
+
+| Variable                  | Used by                     | Required when |
+| ------------------------- | --------------------------- | ------------- |
+| `BULKSIGNER_API_KEY`      | REST API + dashboard login  | Production always |
+| `BULKSIGNER_PFX_PASSWORD` | PFX certificate source      | `CertificateSource = PfxFile` |
+| `BULKSIGNER_HSM_PIN`      | PKCS#11 source              | `CertificateSource = Pkcs11` |
+| `BULKSIGNER_TSA_PASSWORD` | TSA timestamping            | `Timestamping:Enabled = true` and TSA needs auth |
+| `Signing__License`        | Lacuna PKI SDK              | Production always |
+
+Secrets are never logged; their **presence** is logged with safe metadata only (cert subject/issuer/thumbprint/expiry).

--- a/docs.en-us/articles/bulk-signer/dashboard.md
+++ b/docs.en-us/articles/bulk-signer/dashboard.md
@@ -1,0 +1,41 @@
+﻿# Bulk Signer - Dashboard
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+The dashboard is a Blazor Server + MudBlazor UI hosted in the same .NET process as the API.
+
+## Login
+
+Navigate to `/login` and enter the configured API key. A cookie session is issued for the value of `Security:DashboardCookieExpirationHours` (default 8 h). Logout via `/logout`.
+
+The dashboard cookie scheme is separate from the API-key scheme; the API continues to require `X-API-Key`.
+
+## Pages
+
+* **Home (`/`)** — operational status, queue size, totals, storage paths. Auto-refreshes every `Dashboard:HomeRefreshSeconds` (default 5 s).
+* **Jobs (`/jobs`)** — paged, filterable table. Includes `Rescan input` and `Run cleanup now` buttons. Auto-refreshes every `Dashboard:JobsRefreshSeconds` (default 10 s).
+* **Job details (`/jobs/{id}`)** — full metadata, event timeline, output download button for `Completed` jobs. Auto-refresh stops once the job hits a terminal status (`Completed`, `Failed`, `Rejected`, `Canceled`).
+* **Statistics (`/statistics`)** — counts by status, source, and signature format.
+
+Polling intervals are configurable. Auto-refresh stops automatically for terminal statuses. There is no custom SignalR or push messaging in v1 — Blazor's circuit transport handles UI updates.
+
+## Operational actions
+
+The Jobs page includes:
+
+* **Rescan input** — scans the configured Input folder for new files (same handler as `POST /api/input/rescan`).
+* **Run cleanup now** — applies retention immediately (same handler as `POST /api/cleanup/run`).
+
+No file upload from the dashboard in v1 — REST API only.
+
+## Secret hygiene
+
+The dashboard never displays:
+
+* API key
+* PFX password
+* HSM PIN
+* TSA password
+
+Only safe certificate metadata (subject, issuer, thumbprint, expiry) is shown.

--- a/docs.en-us/articles/bulk-signer/docker.md
+++ b/docs.en-us/articles/bulk-signer/docker.md
@@ -1,0 +1,63 @@
+﻿# Bulk Signer - Setup on Docker
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+The provided `Dockerfile` produces a Debian-slim image. **Alpine is intentionally not used** because Pkcs11Interop (used by `Lacuna.Pki.Pkcs11`) and most HSM `.so` libraries are not built for musl, and `System.Security.Cryptography.Xml` has historical quirks on musl that affect XAdES signing.
+
+## Build
+
+```bash
+docker build -t lacuna-bulksigner:v2 .
+```
+
+## Run with docker compose
+
+Create a `.env` next to the `docker-compose.yml`:
+
+```env
+BULKSIGNER_API_KEY=your-api-key
+BULKSIGNER_PFX_PASSWORD=your-pfx-password
+LACUNA_PKI_LICENSE=<lacuna-license-string>
+# BULKSIGNER_HSM_PIN=...        # only if CertificateSource = Pkcs11
+# BULKSIGNER_TSA_PASSWORD=...   # only if TSA needs auth
+```
+
+Then:
+
+```bash
+docker compose up -d --build
+docker compose logs -f bulksigner
+```
+
+Host-side data lives in:
+
+```text
+docker-data/{input,processing,output,error,logs,db}
+docker-config/certificates/   # mount your signer.pfx here, read-only
+```
+
+`./docker-data/` is `.gitignore`d. Drop a file into `docker-data/input/` to exercise the watcher.
+
+## Volumes
+
+The compose file maps each subfolder of `/var/bulksigner/` to a host path under `./docker-data/`, plus a read-only `certificates` mount. Customise as needed.
+
+## Healthcheck
+
+The container's healthcheck hits `http://localhost:8080/api/health` every 30 s. The endpoint is anonymous and cached for 5 s.
+
+## Sizing
+
+Sequential signing is the bottleneck; a single replica handles the configured workload. Don't run multiple replicas against the same folder/database — this is explicitly disallowed in v1.
+
+## Production deployment
+
+* Place the container behind a reverse proxy that terminates TLS (Nginx, Traefik, cloud LB). The app does not terminate TLS itself in v1.
+* Mount real volumes (not bind mounts) for `output/`, `error/`, and `db/` in production.
+* Set `Signing__License` and `BULKSIGNER_API_KEY` via the orchestrator's secret mechanism — never via `docker run -e`.
+
+## See also
+
+* [Configuration](configuration.md) — full env-var checklist
+* [Troubleshooting](troubleshooting.md)

--- a/docs.en-us/articles/bulk-signer/index.md
+++ b/docs.en-us/articles/bulk-signer/index.md
@@ -1,0 +1,87 @@
+﻿# Lacuna Bulk Signer
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+**Bulk Signer** is an on-premises application designed to sign and process large volumes of files securely and automatically. It monitors configured folders for new files, processes them sequentially, applies digital signatures using certificates stored in a secure environment such as an HSM, and saves the signed output in the configured destination folder.
+
+The application supports multiple digital signature formats, including **CAdES**, **XAdES**, and **PAdES**, allowing it to process different types of documents such as generic files, XML files, and PDF documents. After signing, Bulk Signer can also encrypt files using a public key, ensuring that only authorized recipients can access the final content.
+
+Bulk Signer can run on **Windows, Linux, or Docker**, making it suitable for different infrastructure environments. It also provides a **web dashboard** where users can track file processing progress, view statistics, monitor successful and failed operations, and review the current processing status.
+
+In addition to folder monitoring, the application exposes **REST APIs** that allow external systems to submit files for signing, check processing status, and retrieve signed results. Access to the dashboard and APIs is protected by **API key authentication**.
+
+## Principal features
+
+* Automatic folder monitoring for new files
+* Digital signing with certificates stored in an HSM
+* Support for CAdES, XAdES, and PAdES signatures
+* Optional file encryption after signing
+* REST APIs for external file submission
+* Web dashboard for progress tracking and statistics
+* Linux, Windows and Docker support
+* Sequential background processing for predictable execution
+* Verification of signed output before deleting original files
+* Error tracking and processing history
+
+Bulk Signer is ideal for organizations that need a reliable, secure, and auditable solution to automate high-volume digital signing processes.
+
+## Tech stack
+
+| Layer         | Choice |
+| ------------- | ------ |
+| Runtime       | .NET 10, ASP.NET Core Minimal APIs, Blazor Server, hosted workers |
+| UI            | MudBlazor |
+| Persistence   | EF Core 10 + SQLite (auto-migrate at startup) |
+| Signing       | Lacuna.Pki 2.22.3 + Lacuna.Pki.Pkcs11 |
+| Validation    | FluentValidation + `IValidateOptions` |
+| Observability | Serilog (file), Spectre.Console (stdout) |
+| Test          | xUnit, FluentAssertions, `WebApplicationFactory`, BCL `CertificateRequest` |
+
+## Architecture
+
+Bulk Signer follows a **Vertical Slice Architecture** — no MediatR, no Controllers, explicit `Program` class. Each feature slice lives under `src/Lacuna.BulkSigner/Features/<Area>/<Feature>/` and exposes itself via a `MapXxx(this IEndpointRouteBuilder)` extension method. Shared infrastructure lives under `Infrastructure/{Authentication,Certificates,Cleanup,Configuration,Encryption,FileSystem,Logging,Persistence,Processing,Signing,Timestamping,Web,Workers}`. Domain types live under `Domain/{Entities,Enums}`.
+
+## Default endpoints
+
+The app listens on `http://localhost:8080` by default:
+
+* `GET /` — service identification (anonymous)
+* `GET /api/health` — liveness (anonymous)
+* `GET /api/ready` — deep readiness check (anonymous)
+* `POST /api/files` — upload a file for signing (multipart, `X-API-Key`)
+* `GET /api/jobs`, `GET /api/jobs/{id}`, `GET /api/jobs/{id}/output`
+* `POST /api/jobs/{id}/retry`, `POST /api/input/rescan`, `POST /api/cleanup/run`
+* `GET /metrics` (API key)
+* `/scalar/v1` — interactive OpenAPI UI (Development; Production behind `Swagger:EnabledInProduction`)
+* `/` (dashboard) — login at `/login`
+
+## Exit codes
+
+```text
+0  Success / graceful shutdown
+1  Unexpected fatal error
+2  Configuration error
+3  Database initialization/migration error
+4  Required folder creation/access error
+5  Signing certificate initialization error
+```
+
+## Known limitations (v1)
+
+* No automatic retry (manual only)
+* No single-instance lock — run one instance per configured folder set
+* PAdES visible signatures honour reason/location/signer-name but visual rectangle is not yet rendered
+* AES-256-CBC used for content encryption (spec lists AES-256-GCM; can be swapped without API changes)
+* PKCS#11 / HSM integration is wired in but requires hardware-side validation
+* No Kubernetes/Helm manifests in v1
+
+## See also
+
+* [Configuration](configuration.md)
+* [REST API](rest-api.md)
+* [Dashboard](dashboard.md)
+* [Setup on Docker](docker.md)
+* [Setup as a Windows Service](windows-service.md)
+* [Setup with Linux systemd](linux-systemd.md)
+* [Troubleshooting](troubleshooting.md)

--- a/docs.en-us/articles/bulk-signer/linux-systemd.md
+++ b/docs.en-us/articles/bulk-signer/linux-systemd.md
@@ -1,0 +1,74 @@
+﻿# Bulk Signer - Setup with Linux systemd
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+The host detects systemd mode automatically via `Microsoft.Extensions.Hosting.Systemd`.
+
+## Publish
+
+```bash
+dotnet publish src/Lacuna.BulkSigner/Lacuna.BulkSigner.csproj -c Release -r linux-x64 --self-contained false -o /opt/lacuna-bulksigner
+```
+
+## Unit file
+
+`/etc/systemd/system/lacuna-bulksigner.service`:
+
+```ini
+[Unit]
+Description=Lacuna Bulk Signer v2
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+WorkingDirectory=/opt/lacuna-bulksigner
+ExecStart=/usr/bin/dotnet /opt/lacuna-bulksigner/Lacuna.BulkSigner.dll
+Restart=on-failure
+RestartSec=10
+SyslogIdentifier=lacuna-bulksigner
+User=lacuna
+Environment=ASPNETCORE_ENVIRONMENT=Production
+EnvironmentFile=/etc/lacuna-bulksigner/secrets.env
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`/etc/lacuna-bulksigner/secrets.env` (mode `0600`, owned by `lacuna`):
+
+```env
+BULKSIGNER_API_KEY=your-api-key
+BULKSIGNER_PFX_PASSWORD=your-pfx-password
+Signing__License=<lacuna-license-string>
+```
+
+## Enable and start
+
+```bash
+sudo useradd --system --no-create-home lacuna
+sudo chown -R lacuna:lacuna /opt/lacuna-bulksigner /var/lib/lacuna-bulksigner
+sudo systemctl daemon-reload
+sudo systemctl enable --now lacuna-bulksigner.service
+sudo journalctl -u lacuna-bulksigner -f
+```
+
+Logs:
+
+* Structured rolling logs: `data/logs/` (relative to working directory) or wherever `Folders:Logs` is configured.
+* `journalctl` captures Spectre stdout output.
+
+## Upgrade
+
+```bash
+sudo systemctl stop lacuna-bulksigner
+# copy new files over /opt/lacuna-bulksigner
+sudo systemctl start lacuna-bulksigner
+```
+
+## See also
+
+* [Configuration](configuration.md)
+* [Troubleshooting](troubleshooting.md)

--- a/docs.en-us/articles/bulk-signer/rest-api.md
+++ b/docs.en-us/articles/bulk-signer/rest-api.md
@@ -1,0 +1,122 @@
+﻿# Bulk Signer - REST API
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+Base URL: `http://localhost:8080` (default). All `/api/*` endpoints require the `X-API-Key` header except those listed as anonymous. Errors use RFC 7807 `ProblemDetails`.
+
+## Authentication
+
+Send your API key in the `X-API-Key` header:
+
+```http
+GET /api/jobs HTTP/1.1
+X-API-Key: your-api-key
+```
+
+Missing or invalid key returns `401 Unauthorized`.
+
+## Endpoints
+
+### `POST /api/files` — submit a file for signing
+
+`multipart/form-data` with:
+
+* `file` — exactly one file (required)
+* `signatureFormat` — `Auto` | `Cades` | `Xades` | `Pades` (optional; default `Auto`)
+* `encryptionEnabled` — `true` | `false` (optional; defaults to config)
+* `externalReference` — free-form string (optional)
+
+Responses:
+
+* `202 Accepted` with `{ "jobId", "statusUrl", "outputUrl" }`
+* `400 Bad Request` — invalid filename, empty file, unsupported extension
+* `409 Conflict` — a file with the same name is already in the Processing folder
+* `413 Payload Too Large` — exceeds `FileValidation:MaxFileSizeMb`
+
+Example:
+
+```bash
+curl -F "file=@contract.pdf" \
+     -F "encryptionEnabled=false" \
+     -H "X-API-Key: $BULKSIGNER_API_KEY" \
+     http://localhost:8080/api/files
+```
+
+### `GET /api/jobs` — list jobs (paged, filterable)
+
+Query parameters: `page`, `pageSize` (max 200), `status`, `source`, `signatureFormat`, `encryptionEnabled`, `filenameContains`, `externalReferenceContains`, `createdFromUtc`, `createdToUtc`. Default sort is `CreatedAtUtc desc`. Response shape:
+
+```json
+{
+  "total": 312,
+  "page": 1,
+  "pageSize": 25,
+  "items": [ { "id": "…", "status": "Completed", "source": "RestApi" } ]
+}
+```
+
+### `GET /api/jobs/{jobId}` — full job detail and timeline
+
+Returns a job with its events ordered by `CreatedAtUtc`. `404 Not Found` if the id is unknown.
+
+### `GET /api/jobs/{jobId}/output` — download signed/encrypted output
+
+* `200 OK` — streams the file with `Content-Disposition: attachment` and the actual generated filename.
+* `404 Not Found` — unknown job.
+* `409 Conflict` — job is not in `Completed` status.
+* `410 Gone` — output file was removed by retention cleanup.
+
+### `POST /api/jobs/{jobId}/retry` — retry a failed job
+
+Allowed only when:
+
+* The job is `Failed`.
+* The original file is still in the Error folder.
+* No file with the same name exists in the Processing folder.
+
+Response: `202 Accepted` with `{ "jobId": "<new-id>", "retryOf": "<original-id>" }`. The new job links back via `OriginalJobId`.
+
+### `POST /api/input/rescan` — trigger a watched-folder rescan
+
+Returns `200 OK` with `{ "enqueued": <count> }`.
+
+### `POST /api/cleanup/run` — run retention cleanup immediately
+
+Returns `200 OK` with `{ "jobsDeleted", "outputFilesDeleted", "errorFilesDeleted", "operationalEventsDeleted", "filesMissing", "errors" }`.
+
+### `GET /api/health` — anonymous liveness
+
+Returns `200 OK` with `{ "healthy": true, "status": "OK" }`. Cached 5 s.
+
+### `GET /api/ready` — anonymous deep readiness
+
+Checks database, folder write probes, signing certificate, optional TSA, optional encryption certificate. Returns `200 OK` when ready or `503 Service Unavailable` with the failing checks. Cached 5 s.
+
+### `GET /metrics` — counters (API key by default)
+
+```json
+{
+  "totalJobs": 1234,
+  "pendingJobs": 2,
+  "processingJobs": 0,
+  "completedJobs": 1100,
+  "failedJobs": 80,
+  "rejectedJobs": 52,
+  "jobsBySource": { "WatchedFolder": 700, "RestApi": 534 },
+  "jobsBySignatureFormat": { "Cades": 800, "Pades": 380, "Xades": 54 },
+  "averageProcessingMs": 1287.5,
+  "lastSuccessfulUtc": "2026-05-23T18:45:00Z",
+  "lastFailedUtc": "2026-05-22T08:11:30Z"
+}
+```
+
+Set `Metrics:RequireApiKey = false` to expose anonymously.
+
+## Rate limiting
+
+Default 60 requests/min per remote IP. Exceeded requests get `429 Too Many Requests` with a `ProblemDetails` body. Background workers are not rate-limited.
+
+## OpenAPI / Scalar
+
+Visit `/scalar/v1` (Development always; Production only when `Swagger:EnabledInProduction = true`) for an interactive contract.

--- a/docs.en-us/articles/bulk-signer/troubleshooting.md
+++ b/docs.en-us/articles/bulk-signer/troubleshooting.md
@@ -1,0 +1,78 @@
+﻿# Bulk Signer - Troubleshooting
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0    | Graceful shutdown |
+| 1    | Unexpected fatal error — see Serilog log + stderr |
+| 2    | Configuration error — usually a missing required value or invalid value range |
+| 3    | Database initialisation/migration error — check `Database:ConnectionString` and folder permissions for the SQLite file |
+| 4    | Required folder creation/access error — check `Folders:*` paths and write permissions |
+| 5    | Signing certificate initialisation error — bad PFX/PIN/HSM config, expired cert, missing license |
+
+## Lacuna license errors
+
+Symptom: `Lacuna.Pki.LicenseException: License file not found ...`
+
+Cause: `Signing:License` is empty or invalid.
+
+Fix:
+
+* Paste a valid license into `appsettings.Development.json` under `Signing:License`, **or**
+* Set the env var `Signing__License` (note double underscore, no quotes around the value in shell).
+
+## "PFX password not set"
+
+Symptom: startup logs `PFX password not set. Configure environment variable 'BULKSIGNER_PFX_PASSWORD'`.
+
+Fix: export the env var, or set `Signing:PfxFile:DevelopmentPassword` in `appsettings.Development.json` (Development only).
+
+## "A file with the same name is already waiting for processing"
+
+Cause: REST upload or watcher saw a name collision in the Processing folder.
+
+Fix: rename the file or wait for the in-flight job to clear. v1 does not auto-rename to avoid masking concurrency issues.
+
+## REST upload returns `413 Payload Too Large`
+
+Cause: the body exceeded `FileValidation:MaxFileSizeMb` (default 100 MB).
+
+Fix: raise the limit and restart. Kestrel's `MaxRequestBodySize` is set automatically from this option.
+
+## `/api/ready` returns 503
+
+Inspect the JSON body — each subsystem reports `ok` or `fail: <reason>`. Common causes:
+
+* `database`: SQLite file not writable or locked by another instance.
+* `folders`: a configured folder is not writable.
+* `certificate`: the configured cert can't be loaded (missing license, missing password, expired, wrong source for the OS).
+
+## Watched folder isn't picking up files
+
+* Check the file isn't named `.something`, `*.tmp`, or `*.part` (ignored by design).
+* Check `FileValidation:AllowedExtensions` includes your extension.
+* Inspect the rolling log for `Skipping <file>: extension <ext> not in AllowedExtensions`.
+* If the FileSystemWatcher couldn't start (e.g. inside some Docker filesystems), the 30 s periodic rescan will still pick the file up — wait one cycle or hit `POST /api/input/rescan`.
+
+## TSA fails the job
+
+If TSA is enabled, a failed timestamp request fails the job. Disable timestamping (`Timestamping:Enabled = false`) for the queue to drain, then troubleshoot the TSA endpoint.
+
+## Verification fails for signed output
+
+If you're using a self-signed test certificate, signature verification will report chain failures. Either:
+
+* Set `Signing:Verification:FailJobOnVerificationError = false` for dev/CI, or
+* Sign with a chain whose root is trusted by your environment.
+
+## Docker container starts then exits
+
+Most common: `Signing__License` not set in the environment, so cert init fails (exit 5). Check `docker compose logs` for the exit code, then add the missing variable to your `.env` file.
+
+## Database is locked
+
+Running multiple instances against the same SQLite file is unsupported in v1. Stop the extra instances.

--- a/docs.en-us/articles/bulk-signer/windows-service.md
+++ b/docs.en-us/articles/bulk-signer/windows-service.md
@@ -1,0 +1,55 @@
+﻿# Bulk Signer - Setup as a Windows Service
+
+<!-- link to version in Portuguese -->
+<div data-alt-locales="pt-br"></div>
+
+The host detects Windows Service mode automatically via `Microsoft.Extensions.Hosting.WindowsServices` and exits with code 0 on graceful shutdown.
+
+## Publish
+
+```powershell
+dotnet publish src\Lacuna.BulkSigner\Lacuna.BulkSigner.csproj -c Release -r win-x64 --self-contained false -o C:\LacunaBulkSigner
+```
+
+## Install as a service
+
+```powershell
+sc create LacunaBulkSigner binpath="C:\LacunaBulkSigner\Lacuna.BulkSigner.exe" start=auto
+sc description LacunaBulkSigner "Lacuna Bulk Signer v2"
+```
+
+Set environment variables via the service account or registry:
+
+```powershell
+[Environment]::SetEnvironmentVariable("BULKSIGNER_API_KEY", "your-api-key", [EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("BULKSIGNER_PFX_PASSWORD", "your-pfx-password", [EnvironmentVariableTarget]::Machine)
+[Environment]::SetEnvironmentVariable("Signing__License", "<lacuna-license>", [EnvironmentVariableTarget]::Machine)
+```
+
+Start:
+
+```powershell
+sc start LacunaBulkSigner
+```
+
+Check the rolling log under `data\logs\` for startup events. The Spectre console output goes to the service event log/host (not visible by default — use the Serilog file logs for diagnostics).
+
+## Upgrade
+
+```powershell
+sc stop LacunaBulkSigner
+# Copy new files over C:\LacunaBulkSigner
+sc start LacunaBulkSigner
+```
+
+## Uninstall
+
+```powershell
+sc stop LacunaBulkSigner
+sc delete LacunaBulkSigner
+```
+
+## See also
+
+* [Configuration](configuration.md)
+* [Troubleshooting](troubleshooting.md)

--- a/docs.en-us/articles/toc.md
+++ b/docs.en-us/articles/toc.md
@@ -285,6 +285,17 @@
 ## [Changelog](signer/changelog.md)
 <!-- End of Signer -->
 
+<!-- Start of Bulk Signer -->
+# [Bulk Signer](bulk-signer/index.md)
+## [Configuration](bulk-signer/configuration.md)
+## [REST API](bulk-signer/rest-api.md)
+## [Dashboard](bulk-signer/dashboard.md)
+## [Setup on Docker](bulk-signer/docker.md)
+## [Setup as a Windows Service](bulk-signer/windows-service.md)
+## [Setup with Linux systemd](bulk-signer/linux-systemd.md)
+## [Troubleshooting](bulk-signer/troubleshooting.md)
+<!-- End of Bulk Signer -->
+
 <!-- Start of Amplia -->
 # [Amplia](amplia/index.md)
 ## [On-premises](amplia/on-premises/index.md)


### PR DESCRIPTION
## Summary

- Adds the initial English documentation for **Lacuna Bulk Signer** under `docs.en-us/articles/bulk-signer/` (8 articles: index, configuration, REST API, dashboard, Docker setup, Windows Service setup, Linux systemd setup, troubleshooting).
- Registers the product in `docs.en-us/articles/toc.md` between Signer and Amplia.
- All article files use UTF-8 with BOM per the repository convention. Each file includes the `<div data-alt-locales="pt-br">` stub so the language switcher renders correctly until the Portuguese version is added.
- Source material: [LacunaBulkSigner/README.md](https://github.com/LacunaSoftware/LacunaBulkSigner/blob/main/README.md) and [LacunaBulkSigner/docs/](https://github.com/LacunaSoftware/LacunaBulkSigner/tree/main/docs).

## Notes

- Layout is flat (no `on-premises/` subfolder) because Bulk Signer has no SaaS counterpart — every deployment is on-premises.
- Internal "spec §N" references from the source were removed (they pointed to a private spec document not part of this portal).
- Portuguese (`docs.pt-br`) version is **not** included in this PR — to follow.

## Test plan

- [x] Build the English site locally: `cd docs.en-us; docfx.exe docfx.json`
- [x] Confirm `bulk-signer/` pages render and the new TOC block appears between Signer and Amplia
- [ ] Click through each See also / cross-link to confirm relative paths resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)