### PR TITLE
Trim internal-focused sections from Bulk Signer index

### DIFF
--- a/docs.en-us/articles/bulk-signer/index.md
+++ b/docs.en-us/articles/bulk-signer/index.md
@@ -26,17 +26,6 @@ In addition to folder monitoring, the application exposes **REST APIs** that all
 
 Bulk Signer is ideal for organizations that need a reliable, secure, and auditable solution to automate high-volume digital signing processes.
 
-## Tech stack
-
-| Layer         | Choice |
-| ------------- | ------ |
-| Runtime       | .NET 10, ASP.NET Core Minimal APIs, Blazor Server, hosted workers |
-| UI            | MudBlazor |
-| Persistence   | EF Core 10 + SQLite (auto-migrate at startup) |
-| Signing       | Lacuna.Pki 2.22.3 + Lacuna.Pki.Pkcs11 |
-| Validation    | FluentValidation + `IValidateOptions` |
-| Observability | Serilog (file), Spectre.Console (stdout) |
-| Test          | xUnit, FluentAssertions, `WebApplicationFactory`, BCL `CertificateRequest` |
 
 ## Architecture
 
@@ -45,10 +34,6 @@ The diagram below summarises how a file flows through the system, from submissio
 ![Bulk Signer architecture](images/architecture.png)
 
 Processing is sequential and idempotent at each step. Any failure short-circuits the pipeline, moves the file to the **Error Directory**, and emits failure telemetry to the observability system — the original input is only deleted after a verified output has been written.
-
-### Code layout
-
-Bulk Signer follows a **Vertical Slice Architecture** — no MediatR, no Controllers, explicit `Program` class. Each feature slice lives under `src/Lacuna.BulkSigner/Features/<Area>/<Feature>/` and exposes itself via a `MapXxx(this IEndpointRouteBuilder)` extension method. Shared infrastructure lives under `Infrastructure/{Authentication,Certificates,Cleanup,Configuration,Encryption,FileSystem,Logging,Persistence,Processing,Signing,Timestamping,Web,Workers}`. Domain types live under `Domain/{Entities,Enums}`.
 
 ## Default endpoints
 
@@ -74,15 +59,6 @@ The app listens on `http://localhost:8080` by default:
 4  Required folder creation/access error
 5  Signing certificate initialization error
 ```
-
-## Known limitations (v1)
-
-* No automatic retry (manual only)
-* No single-instance lock — run one instance per configured folder set
-* PAdES visible signatures honour reason/location/signer-name but visual rectangle is not yet rendered
-* AES-256-CBC used for content encryption (spec lists AES-256-GCM; can be swapped without API changes)
-* PKCS#11 / HSM integration is wired in but requires hardware-side validation
-* No Kubernetes/Helm manifests in v1
 
 ## See also
 


### PR DESCRIPTION
## Summary

Follow-up to #42. Removes three sections from `bulk-signer/index.md` that target contributors or ops engineers rather than the public docs audience:

- **Tech stack** — internal implementation detail (.NET version, EF Core, MudBlazor, etc.)
- **Code layout** — Vertical Slice description of `src/Lacuna.BulkSigner/Features/…`
- **Known limitations (v1)** — release-engineering caveats that belong in a changelog, not a landing page

The architecture diagram and processing-flow caption remain as the visual overview.

## Base branch

This PR targets `bulk-signer/initial-docs` (the head of #42), so the diff shows only the cleanup. Merge #42 first, then this — or change the base to `master` after #42 lands.

## Test plan

- [x] Build the English site locally: `cd docs.en-us; docfx.exe docfx.json`
- [x] Confirm `bulk-signer/index.md` renders without the removed sections and the architecture image still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)